### PR TITLE
Updating pom.xml

### DIFF
--- a/chapter5-api/pom.xml
+++ b/chapter5-api/pom.xml
@@ -18,11 +18,10 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.11.600</version>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.17.46</version>
         <type>pom</type>
-        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The lambda function will crash and return an internal server error.
the pom must be updated in order to solve this problem in chapter 5
ref: 
https://stackoverflow.com/questions/66452388/java-lang-classnotfoundexception-com-amazonaws-transform-enhancedjsonerrorunmar
https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/javav2/example_code/secretsmanager/pom.xml